### PR TITLE
Add auto-tagging support and --tag option

### DIFF
--- a/stable-patches/tagging.patch
+++ b/stable-patches/tagging.patch
@@ -1,0 +1,161 @@
+diff --git a/src/tool_cb_wrt.c b/src/tool_cb_wrt.c
+index 724706b..b9d2f34 100644
+--- a/src/tool_cb_wrt.c
++++ b/src/tool_cb_wrt.c
+@@ -28,6 +28,13 @@
+ #include "tool_cb_wrt.h"
+ #include "tool_operate.h"
+ 
++#ifdef __MVS__
++#include <zos.h>
++#include <fcntl.h>
++#include <_Ccsid.h>
++
++#endif
++
+ #include "memdebug.h" /* keep this as LAST include */
+ 
+ #ifdef _WIN32
+@@ -101,6 +108,17 @@ bool tool_create_output_file(struct OutStruct *outs,
+           curlx_strerror(errno, errbuf, sizeof(errbuf)));
+     return FALSE;
+   }
++
++#ifdef __MVS__
++  if(config->local_ccsid) {
++    int fd = fileno(file);
++    if(config->local_ccsid == 65535)
++      __chgfdccsid(fd, FT_BINARY);
++    else
++      __chgfdccsid(fd, (int)config->local_ccsid);
++  }
++#endif
++
+   outs->s_isreg = TRUE;
+   outs->fopened = TRUE;
+   outs->stream = file;
+@@ -310,6 +328,16 @@ size_t tool_write_cb(char *buffer, size_t sz, size_t nmemb, void *userdata)
+   if(!outs->stream && !tool_create_output_file(outs, per->config))
+     return CURL_WRITEFUNC_ERROR;
+ 
++#ifdef __MVS__
++  if(config->local_ccsid == 0 && outs->bytes == 0 && !config->resume_from && !getenv("_ENCODE_FILE_NEW")) {
++    int ccsid = __guess_ue(buffer, bytes, NULL, 0);
++    if(ccsid == 65535)
++      __chgfdccsid(fileno(outs->stream), FT_BINARY);
++    else
++      __chgfdccsid(fileno(outs->stream), ccsid);
++  }
++#endif
++
+   if(is_tty && (outs->bytes < 2000) && !config->terminal_binary_ok) {
+     /* binary output to terminal? */
+     if(memchr(buffer, 0, bytes)) {
+diff --git a/src/tool_cfgable.h b/src/tool_cfgable.h
+index 630f23f..9c08dda 100644
+--- a/src/tool_cfgable.h
++++ b/src/tool_cfgable.h
+@@ -183,6 +183,7 @@ struct OperationConfig {
+   long proxy_ssl_version;
+   long ip_version;
+   long create_file_mode; /* CURLOPT_NEW_FILE_PERMS */
++  unsigned long local_ccsid;
+   long low_speed_limit;
+   long low_speed_time;
+   long ip_tos;         /* IP Type of Service */
+diff --git a/src/tool_getparam.c b/src/tool_getparam.c
+index 5624d3c..894d101 100644
+--- a/src/tool_getparam.c
++++ b/src/tool_getparam.c
+@@ -23,6 +23,11 @@
+  ***************************************************************************/
+ #include "tool_setup.h"
+ 
++#ifdef __MVS__
++#include <zos.h>
++#include <_Ccsid.h>
++#endif
++
+ #include "tool_cfgable.h"
+ #include "tool_cb_prg.h"
+ #include "tool_filetime.h"
+@@ -332,6 +337,7 @@ static const struct LongShort aliases[]= {
+   {"stderr",                     ARG_FILE, ' ', C_STDERR},
+   {"styled-output",              ARG_BOOL, ' ', C_STYLED_OUTPUT},
+   {"suppress-connect-headers",   ARG_BOOL, ' ', C_SUPPRESS_CONNECT_HEADERS},
++  {"tag",                        ARG_STRG, ' ', C_TAG},
+   {"tcp-fastopen",               ARG_BOOL, ' ', C_TCP_FASTOPEN},
+   {"tcp-nodelay",                ARG_BOOL, ' ', C_TCP_NODELAY},
+   {"telnet-option",              ARG_STRG, 't', C_TELNET_OPTION},
+@@ -2819,6 +2825,25 @@ static ParameterError opt_string(struct OperationConfig *config,
+   case C_UPLOAD_FLAGS: /* --upload-flags */
+     err = parse_upload_flags(config, nextarg);
+     break;
++  case C_TAG: /* --tag */
++#ifdef __MVS__
++    if(!strcasecmp(nextarg, "auto"))
++      config->local_ccsid = 0;
++    else if(!strcasecmp(nextarg, "binary"))
++      config->local_ccsid = 65535;
++    else {
++      unsigned short ccsid = __toCcsid((char*)nextarg);
++      if(ccsid == 0) {
++        warnf("Invalid --tag value: %s", nextarg);
++        err = PARAM_BAD_USE;
++      } else {
++        config->local_ccsid = ccsid;
++      }
++    }
++#else
++    warnf("--tag is ignored on this platform");
++#endif
++    break;
+   }
+   return err;
+ }
+diff --git a/src/tool_getparam.h b/src/tool_getparam.h
+index 6b37cc5..dd9da38 100644
+--- a/src/tool_getparam.h
++++ b/src/tool_getparam.h
+@@ -270,6 +270,7 @@ typedef enum {
+   C_STDERR,
+   C_STYLED_OUTPUT,
+   C_SUPPRESS_CONNECT_HEADERS,
++  C_TAG,
+   C_TCP_FASTOPEN,
+   C_TCP_NODELAY,
+   C_TELNET_OPTION,
+diff --git a/src/tool_operate.c b/src/tool_operate.c
+index f290a28..0d90389 100644
+--- a/src/tool_operate.c
++++ b/src/tool_operate.c
+@@ -23,6 +23,13 @@
+  ***************************************************************************/
+ #include "tool_setup.h"
+ 
++#ifdef __MVS__
++#include <zos.h>
++#include <fcntl.h>
++#include <_Ccsid.h>
++
++#endif
++
+ #ifdef HAVE_LOCALE_H
+ #  include <locale.h>
+ #endif
+@@ -1077,6 +1084,15 @@ static CURLcode setup_outfile(struct OperationConfig *config,
+       errorf("cannot open '%s'", per->outfile);
+       return CURLE_WRITE_ERROR;
+     }
++#ifdef __MVS__
++    if(config->local_ccsid) {
++      int fd = fileno(file);
++      if(config->local_ccsid == 65535)
++        __chgfdccsid(fd, FT_BINARY);
++      else
++        __chgfdccsid(fd, (int)config->local_ccsid);
++    }
++#endif
+     outs->fopened = TRUE;
+     outs->stream = file;
+     outs->init = config->resume_from;


### PR DESCRIPTION
* Adds --tag <ccsid> option to explicitly set the tag of an output file
* --tag auto (default) - guesses ccsid based on the file content

Related issue: https://github.com/zopencommunity/curlport/issues/50
