### PR TITLE
zos: fix MVS dataset upload with --upload-encoding

### DIFF
--- a/stable-patches/add-download-encoding.patch
+++ b/stable-patches/add-download-encoding.patch
@@ -1,6 +1,6 @@
 diff --git a/docs/cmdline-opts/download-encoding.md b/docs/cmdline-opts/download-encoding.md
 new file mode 100644
-index 0000000..3e67aed
+index 0000000..f5f8746
 --- /dev/null
 +++ b/docs/cmdline-opts/download-encoding.md
 @@ -0,0 +1,30 @@

--- a/stable-patches/configure.patch
+++ b/stable-patches/configure.patch
@@ -1,8 +1,8 @@
 diff --git a/configure b/configure
-index e47b24d..f620501 100755
+index 368831b..f59112c 100755
 --- a/configure
 +++ b/configure
-@@ -9723,6 +9723,10 @@ aix[4-9]*)
+@@ -9834,6 +9834,10 @@ aix[4-9]*)
    lt_cv_deplibs_check_method=pass_all
    ;;
  

--- a/stable-patches/src/tool_cb_rea.c.patch
+++ b/stable-patches/src/tool_cb_rea.c.patch
@@ -1,5 +1,5 @@
 diff --git a/src/tool_cb_rea.c b/src/tool_cb_rea.c
-index b5bc53a..32957ee 100644
+index b5bc53a..1d21c8c 100644
 --- a/src/tool_cb_rea.c
 +++ b/src/tool_cb_rea.c
 @@ -125,15 +125,32 @@ size_t tool_read_cb(char *buffer, size_t sz, size_t nmemb, void *userdata)
@@ -54,12 +54,12 @@ index b5bc53a..32957ee 100644
 +
 +    /* Handle dataset encoding (backward compatibility) */
 +    if(per->convert_ascii) {
-+      __e2a_s(buffer);
++      __e2a_l(buffer, (size_t)rc);
 +    }
 +    /* Handle z/OS UNIX file encoding */
-+    else if(config->upload_encoding_unix && per->encoding_ctx) {
++    else if(config->upload_encoding_unix && per->upload_encoding_ctx) {
 +      size_t size = (size_t)rc;
-+      if(encoding_convert(per->encoding_ctx, buffer, &size,
++      if(encoding_convert(per->upload_encoding_ctx, buffer, &size,
 +                          CURL_MAX_WRITE_SIZE) == 0) {
 +        rc = (ssize_t)size;
 +      }

--- a/stable-patches/src/tool_cb_rea.c.patch
+++ b/stable-patches/src/tool_cb_rea.c.patch
@@ -1,8 +1,8 @@
 diff --git a/src/tool_cb_rea.c b/src/tool_cb_rea.c
-index eb23f9b..be3cb2d 100644
+index b5bc53a..32957ee 100644
 --- a/src/tool_cb_rea.c
 +++ b/src/tool_cb_rea.c
-@@ -130,15 +130,31 @@ size_t tool_read_cb(char *buffer, size_t sz, size_t nmemb, void *userdata)
+@@ -125,15 +125,32 @@ size_t tool_read_cb(char *buffer, size_t sz, size_t nmemb, void *userdata)
    else
  #endif /* _WIN32 */
    {
@@ -13,8 +13,9 @@ index eb23f9b..be3cb2d 100644
 -        config->readbusy = TRUE;
 -        return CURL_READFUNC_PAUSE;
 +#ifdef __MVS__
-+    /* z/OS: Use fread for datasets opened with fopen */
++    /* z/OS: Use fread for datasets opened with text mode */
 +    if(per->use_fopen && per->infp) {
++      /* Text mode automatically converts record boundaries to \n */
 +      rc = (ssize_t)fread(buffer, 1, sz * nmemb, per->infp);
 +      if(rc == 0) {
 +        if(ferror(per->infp)) {
@@ -42,7 +43,7 @@ index eb23f9b..be3cb2d 100644
      }
    }
  
-@@ -151,6 +167,26 @@ size_t tool_read_cb(char *buffer, size_t sz, size_t nmemb, void *userdata)
+@@ -146,6 +163,26 @@ size_t tool_read_cb(char *buffer, size_t sz, size_t nmemb, void *userdata)
            delta);
      rc = (ssize_t)(per->uploadfilesize - per->uploadedsofar);
    }

--- a/stable-patches/src/tool_cb_wrt.c.patch
+++ b/stable-patches/src/tool_cb_wrt.c.patch
@@ -1,5 +1,5 @@
 diff --git a/src/tool_cb_wrt.c b/src/tool_cb_wrt.c
-index 1d2b81e..cd4a311 100644
+index 133573a..c1b7a84 100644
 --- a/src/tool_cb_wrt.c
 +++ b/src/tool_cb_wrt.c
 @@ -28,6 +28,14 @@
@@ -25,7 +25,7 @@ index 1d2b81e..cd4a311 100644
    DEBUGASSERT(outs);
    DEBUGASSERT(config);
    DEBUGASSERT(fname && *fname);
-@@ -99,6 +108,22 @@ bool tool_create_output_file(struct OutStruct *outs,
+@@ -103,6 +112,20 @@ bool tool_create_output_file(struct OutStruct *outs,
            curlx_strerror(errno, errbuf, sizeof(errbuf)));
      return FALSE;
    }
@@ -35,11 +35,9 @@ index 1d2b81e..cd4a311 100644
 +    int rc_tag;
 +    if(config->local_ccsid == 65535) {
 +      rc_tag = __chgfdccsid(fd, FT_BINARY);
-+      fprintf(stderr, "DEBUG: __chgfdccsid(FT_BINARY) returns %d, errno=%d\n", rc_tag, errno);
 +    }
 +    else {
 +      rc_tag = __chgfdccsid(fd, (int)config->local_ccsid);
-+      fprintf(stderr, "DEBUG: __chgfdccsid(%d) returns %d, errno=%d\n", (int)config->local_ccsid, rc_tag, errno);
 +    }
 +  }
 +#endif
@@ -48,7 +46,7 @@ index 1d2b81e..cd4a311 100644
    outs->regular_file = TRUE;
    outs->fopened = TRUE;
    outs->stream = file;
-@@ -308,6 +333,55 @@ size_t tool_write_cb(char *buffer, size_t sz, size_t nmemb, void *userdata)
+@@ -311,6 +334,53 @@ size_t tool_write_cb(char *buffer, size_t sz, size_t nmemb, void *userdata)
    if(!outs->stream && !tool_create_output_file(outs, per->config))
      return CURL_WRITEFUNC_ERROR;
  
@@ -92,11 +90,9 @@ index 1d2b81e..cd4a311 100644
 +    int rc_tag;
 +    if(config->local_ccsid == 65535) {
 +      rc_tag = __chgfdccsid(fileno(outs->stream), FT_BINARY);
-+      fprintf(stderr, "DEBUG: write_cb __chgfdccsid(FT_BINARY) returns %d\n", rc_tag);
 +    }
 +    else {
 +      rc_tag = __chgfdccsid(fileno(outs->stream), (int)config->local_ccsid);
-+      fprintf(stderr, "DEBUG: write_cb __chgfdccsid(%d) returns %d\n", (int)config->local_ccsid, rc_tag);
 +    }
 +  }
 +#endif
@@ -104,7 +100,7 @@ index 1d2b81e..cd4a311 100644
    if(is_tty && (outs->bytes < 2000) && !config->terminal_binary_ok) {
      /* binary output to terminal? */
      if(memchr(buffer, 0, bytes)) {
-@@ -342,6 +416,14 @@ size_t tool_write_cb(char *buffer, size_t sz, size_t nmemb, void *userdata)
+@@ -345,6 +415,14 @@ size_t tool_write_cb(char *buffer, size_t sz, size_t nmemb, void *userdata)
      /* we added this amount of data to the output */
      outs->bytes += bytes;
  

--- a/stable-patches/src/tool_cb_wrt.c.patch
+++ b/stable-patches/src/tool_cb_wrt.c.patch
@@ -1,5 +1,5 @@
 diff --git a/src/tool_cb_wrt.c b/src/tool_cb_wrt.c
-index 133573a..c1b7a84 100644
+index 133573a..48eb33d 100644
 --- a/src/tool_cb_wrt.c
 +++ b/src/tool_cb_wrt.c
 @@ -28,6 +28,14 @@
@@ -46,31 +46,37 @@ index 133573a..c1b7a84 100644
    outs->regular_file = TRUE;
    outs->fopened = TRUE;
    outs->stream = file;
-@@ -311,6 +334,53 @@ size_t tool_write_cb(char *buffer, size_t sz, size_t nmemb, void *userdata)
+@@ -311,6 +334,59 @@ size_t tool_write_cb(char *buffer, size_t sz, size_t nmemb, void *userdata)
    if(!outs->stream && !tool_create_output_file(outs, per->config))
      return CURL_WRITEFUNC_ERROR;
  
 +#ifdef __MVS__
 +  /* Handle download encoding conversion */
 +  char *converted_buffer = NULL;
-+  if(config->download_encoding && per->encoding_ctx) {
-+    encoding_ctx_t *ctx = (encoding_ctx_t*)per->encoding_ctx;
++  if(config->download_encoding && per->download_encoding_ctx) {
++    encoding_ctx_t *ctx = (encoding_ctx_t*)per->download_encoding_ctx;
 +    if(ctx->mode != ENCODING_NONE) {
 +      /* Convert downloaded data using encoding context */
-+      size_t size = bytes;
-+      converted_buffer = malloc(bytes * 2); /* Allow for expansion */
-+      if(converted_buffer) {
-+        memcpy(converted_buffer, buffer, bytes);
-+        if(encoding_convert(per->encoding_ctx, converted_buffer, &size, 
-+                            bytes * 2) == 0) {
-+          buffer = converted_buffer;
-+          bytes = size;
-+        }
-+        else {
-+          /* Conversion failed, free buffer and use original */
-+          free(converted_buffer);
-+          converted_buffer = NULL;
-+        }
++      size_t conv_size = bytes;
++      size_t needed = bytes * 2;
++      /* Use cached buffer, growing if needed */
++      if(!ctx->conv_buf || ctx->conv_buf_size < needed) {
++        free(ctx->conv_buf);
++        ctx->conv_buf_size = needed;
++        ctx->conv_buf = malloc(ctx->conv_buf_size);
++      }
++      converted_buffer = ctx->conv_buf;
++      if(!converted_buffer)
++        return CURL_WRITEFUNC_ERROR;
++      memcpy(converted_buffer, buffer, bytes);
++      if(encoding_convert(per->download_encoding_ctx, converted_buffer,
++                          &conv_size, ctx->conv_buf_size) == 0) {
++        buffer = converted_buffer;
++        bytes = conv_size;
++      }
++      else {
++        /* Conversion failed â abort to prevent corrupted output */
++        return CURL_WRITEFUNC_ERROR;
 +      }
 +    }
 +  }
@@ -100,16 +106,14 @@ index 133573a..c1b7a84 100644
    if(is_tty && (outs->bytes < 2000) && !config->terminal_binary_ok) {
      /* binary output to terminal? */
      if(memchr(buffer, 0, bytes)) {
-@@ -345,6 +415,14 @@ size_t tool_write_cb(char *buffer, size_t sz, size_t nmemb, void *userdata)
+@@ -345,6 +421,12 @@ size_t tool_write_cb(char *buffer, size_t sz, size_t nmemb, void *userdata)
      /* we added this amount of data to the output */
      outs->bytes += bytes;
  
 +#ifdef __MVS__
-+  /* Free converted buffer if it was allocated */
-+  if(converted_buffer) {
-+    free(converted_buffer);
-+    converted_buffer = NULL;
-+  }
++  /* converted_buffer points to ctx->conv_buf which is freed by
++   * encoding_cleanup() â no per-call free needed */
++  (void)converted_buffer;
 +#endif
 +
    if(config->readbusy) {

--- a/stable-patches/src/tool_cfgable.c.patch
+++ b/stable-patches/src/tool_cfgable.c.patch
@@ -1,8 +1,8 @@
 diff --git a/src/tool_cfgable.c b/src/tool_cfgable.c
-index b907b24..ec6b9c3 100644
+index 3feb3e7..bd5e69f 100644
 --- a/src/tool_cfgable.c
 +++ b/src/tool_cfgable.c
-@@ -184,6 +184,9 @@ static void free_config_fields(struct OperationConfig *config)
+@@ -160,6 +160,9 @@ static void free_config_fields(struct OperationConfig *config)
    curlx_safefree(config->krblevel);
    curlx_safefree(config->oauth_bearer);
    curlx_safefree(config->sasl_authzid);

--- a/stable-patches/src/tool_cfgable.h.patch
+++ b/stable-patches/src/tool_cfgable.h.patch
@@ -1,18 +1,18 @@
 diff --git a/src/tool_cfgable.h b/src/tool_cfgable.h
-index 329691e..1d7116f 100644
+index 0f8bc6f..07ca60c 100644
 --- a/src/tool_cfgable.h
 +++ b/src/tool_cfgable.h
-@@ -178,6 +178,9 @@ struct OperationConfig {
+@@ -172,6 +172,9 @@ struct OperationConfig {
    long proxy_ssl_version;
    long ip_version;
    long create_file_mode; /* CURLOPT_NEW_FILE_PERMS */
-+  unsigned long local_ccsid;
++  unsigned short local_ccsid;
 +  char *download_encoding;    /* --download-encoding (replaces --tag) */
 +  char *upload_encoding_unix; /* --upload-encoding for z/OS UNIX files */
    long low_speed_limit;
    long low_speed_time;
    long ip_tos;         /* IP Type of Service */
-@@ -219,6 +222,7 @@ struct OperationConfig {
+@@ -213,6 +216,7 @@ struct OperationConfig {
      CLOBBER_ALWAYS /* If the file exists, always overwrite it */
    } file_clobber_mode;
    unsigned char upload_flags; /* Bitmask for --upload-flags */

--- a/stable-patches/src/tool_getparam.c.patch
+++ b/stable-patches/src/tool_getparam.c.patch
@@ -1,5 +1,5 @@
 diff --git a/src/tool_getparam.c b/src/tool_getparam.c
-index 841c6ff..cd64788 100644
+index 35c01b1..0e3a4df 100644
 --- a/src/tool_getparam.c
 +++ b/src/tool_getparam.c
 @@ -23,6 +23,11 @@
@@ -14,7 +14,7 @@ index 841c6ff..cd64788 100644
  #include "tool_cfgable.h"
  #include "tool_cb_prg.h"
  #include "tool_filetime.h"
-@@ -124,6 +129,7 @@ static const struct LongShort aliases[]= {
+@@ -118,6 +123,7 @@ static const struct LongShort aliases[]= {
    {"dns-ipv4-addr",              ARG_STRG, ' ', C_DNS_IPV4_ADDR},
    {"dns-ipv6-addr",              ARG_STRG, ' ', C_DNS_IPV6_ADDR},
    {"dns-servers",                ARG_STRG, ' ', C_DNS_SERVERS},
@@ -22,7 +22,7 @@ index 841c6ff..cd64788 100644
    {"doh-cert-status",            ARG_BOOL|ARG_TLS, ' ', C_DOH_CERT_STATUS},
    {"doh-insecure",               ARG_BOOL|ARG_TLS, ' ', C_DOH_INSECURE},
    {"doh-url",                    ARG_STRG, ' ', C_DOH_URL},
-@@ -330,6 +336,7 @@ static const struct LongShort aliases[]= {
+@@ -325,6 +331,7 @@ static const struct LongShort aliases[]= {
    {"stderr",                     ARG_FILE, ' ', C_STDERR},
    {"styled-output",              ARG_BOOL, ' ', C_STYLED_OUTPUT},
    {"suppress-connect-headers",   ARG_BOOL, ' ', C_SUPPRESS_CONNECT_HEADERS},
@@ -30,7 +30,7 @@ index 841c6ff..cd64788 100644
    {"tcp-fastopen",               ARG_BOOL, ' ', C_TCP_FASTOPEN},
    {"tcp-nodelay",                ARG_BOOL, ' ', C_TCP_NODELAY},
    {"telnet-option",              ARG_STRG, 't', C_TELNET_OPTION},
-@@ -358,6 +365,7 @@ static const struct LongShort aliases[]= {
+@@ -353,6 +360,7 @@ static const struct LongShort aliases[]= {
    {"trace-ids",                  ARG_BOOL, ' ', C_TRACE_IDS},
    {"trace-time",                 ARG_BOOL, ' ', C_TRACE_TIME},
    {"unix-socket",                ARG_FILE, ' ', C_UNIX_SOCKET},
@@ -38,16 +38,26 @@ index 841c6ff..cd64788 100644
    {"upload-file",                ARG_FILE, 'T', C_UPLOAD_FILE},
    {"upload-flags",               ARG_STRG, ' ', C_UPLOAD_FLAGS},
    {"url",                        ARG_STRG, ' ', C_URL},
-@@ -2915,6 +2923,42 @@ static ParameterError opt_string(struct OperationConfig *config,
+@@ -2930,6 +2938,52 @@ static ParameterError opt_string(struct OperationConfig *config,
    case C_UPLOAD_FLAGS: /* --upload-flags */
      err = parse_upload_flags(config, nextarg);
      break;
 +  case C_UPLOAD_ENCODING: /* --upload-encoding */
-+    /* For datasets, store in upload_encoding for backward compatibility */
-+    /* For z/OS UNIX files, store in upload_encoding_unix */
-+    err = getstr(&config->upload_encoding, nextarg, DENY_BLANK);
-+    if(!err)
-+      err = getstr(&config->upload_encoding_unix, nextarg, DENY_BLANK);
++#ifdef __MVS__
++    if(strcasecmp(nextarg, "ascii") && strcasecmp(nextarg, "binary") &&
++       strcasecmp(nextarg, "e2a") && strcasecmp(nextarg, "a2e") &&
++       __toCcsid((char*)nextarg) == 0) {
++      warnf("Invalid --upload-encoding value: %s", nextarg);
++      err = PARAM_BAD_USE;
++    }
++    else {
++      err = getstr(&config->upload_encoding, nextarg, DENY_BLANK);
++      if(!err)
++        err = getstr(&config->upload_encoding_unix, nextarg, DENY_BLANK);
++    }
++#else
++    warnf("--upload-encoding is ignored on this platform");
++#endif
 +    break;
 +  case C_DOWNLOAD_ENCODING: /* --download-encoding (and --tag alias) */
 +#ifdef __MVS__

--- a/stable-patches/src/tool_getparam.h.patch
+++ b/stable-patches/src/tool_getparam.h.patch
@@ -1,16 +1,8 @@
 diff --git a/src/tool_getparam.h b/src/tool_getparam.h
-index 44eb361..a785be8 100644
+index 32476d3..6bb594a 100644
 --- a/src/tool_getparam.h
 +++ b/src/tool_getparam.h
-@@ -270,6 +270,7 @@ typedef enum {
-   C_STDERR,
-   C_STYLED_OUTPUT,
-   C_SUPPRESS_CONNECT_HEADERS,
-+  C_TAG,
-   C_TCP_FASTOPEN,
-   C_TCP_NODELAY,
-   C_TELNET_OPTION,
-@@ -297,6 +298,8 @@ typedef enum {
+@@ -298,6 +298,8 @@ typedef enum {
    C_TRACE_TIME,
    C_IP_TOS,
    C_UNIX_SOCKET,

--- a/stable-patches/src/tool_listhelp.c.patch
+++ b/stable-patches/src/tool_listhelp.c.patch
@@ -1,5 +1,5 @@
 diff --git a/src/tool_listhelp.c b/src/tool_listhelp.c
-index 9a8a7d9..28d37f2 100644
+index c0b0af7..409dd4d 100644
 --- a/src/tool_listhelp.c
 +++ b/src/tool_listhelp.c
 @@ -166,6 +166,9 @@ const struct helptxt helptext[] = {
@@ -12,7 +12,7 @@ index 9a8a7d9..28d37f2 100644
    { "    --dump-ca-embed",
      "Write the embedded CA bundle to standard output",
      CURLHELP_HTTP | CURLHELP_PROXY | CURLHELP_TLS },
-@@ -821,9 +824,12 @@ const struct helptxt helptext[] = {
+@@ -824,6 +827,9 @@ const struct helptxt helptext[] = {
    { "    --unix-socket <path>",
      "Connect through this Unix domain socket",
      CURLHELP_CONNECTION },
@@ -21,8 +21,4 @@ index 9a8a7d9..28d37f2 100644
 +    CURLHELP_UPLOAD },
    { "-T, --upload-file <file>",
      "Transfer local FILE to destination",
--    CURLHELP_IMPORTANT | CURLHELP_UPLOAD },
-+    CURLHELP_UPLOAD },
-   { "    --upload-flags <flags>",
-     "IMAP upload behavior",
-     CURLHELP_CURL | CURLHELP_OUTPUT },
+     CURLHELP_IMPORTANT | CURLHELP_UPLOAD },

--- a/stable-patches/src/tool_operate.c.patch
+++ b/stable-patches/src/tool_operate.c.patch
@@ -1,5 +1,5 @@
 diff --git a/src/tool_operate.c b/src/tool_operate.c
-index c9bb636..e1e0c27 100644
+index c9bb636..07f15db 100644
 --- a/src/tool_operate.c
 +++ b/src/tool_operate.c
 @@ -25,6 +25,14 @@
@@ -17,22 +17,27 @@ index c9bb636..e1e0c27 100644
  #ifdef HAVE_LOCALE_H
  #  include <locale.h>
  #endif
-@@ -236,6 +244,14 @@ static struct per_transfer *del_per_transfer(struct per_transfer *per)
+@@ -236,6 +244,19 @@ static struct per_transfer *del_per_transfer(struct per_transfer *per)
      transfersl = p;
  
    curlx_free(per->uploadfile);
 +#ifdef __MVS__
-+  /* Clean up encoding context */
-+  if(per->encoding_ctx) {
-+    encoding_cleanup((encoding_ctx_t*)per->encoding_ctx);
-+    free(per->encoding_ctx);
-+    per->encoding_ctx = NULL;
++  /* Clean up encoding contexts */
++  if(per->upload_encoding_ctx) {
++    encoding_cleanup((encoding_ctx_t*)per->upload_encoding_ctx);
++    free(per->upload_encoding_ctx);
++    per->upload_encoding_ctx = NULL;
++  }
++  if(per->download_encoding_ctx) {
++    encoding_cleanup((encoding_ctx_t*)per->download_encoding_ctx);
++    free(per->download_encoding_ctx);
++    per->download_encoding_ctx = NULL;
 +  }
 +#endif
    curlx_free(per->outfile);
    curlx_free(per->url);
    curl_easy_cleanup(per->curl);
-@@ -244,6 +260,17 @@ static struct per_transfer *del_per_transfer(struct per_transfer *per)
+@@ -244,6 +265,17 @@ static struct per_transfer *del_per_transfer(struct per_transfer *per)
    return n;
  }
  
@@ -50,7 +55,7 @@ index c9bb636..e1e0c27 100644
  static CURLcode pre_transfer(struct per_transfer *per)
  {
    curl_off_t uploadfilesize = -1;
-@@ -251,6 +278,40 @@ static CURLcode pre_transfer(struct per_transfer *per)
+@@ -251,6 +283,40 @@ static CURLcode pre_transfer(struct per_transfer *per)
    CURLcode result = CURLE_OK;
  
    if(per->uploadfile && !stdin_upload(per->uploadfile)) {
@@ -91,7 +96,7 @@ index c9bb636..e1e0c27 100644
      /* VMS Note:
       *
       * Reading binary from files can be a problem... Only FIXED, VAR
-@@ -299,6 +360,7 @@ static CURLcode pre_transfer(struct per_transfer *per)
+@@ -299,6 +365,7 @@ static CURLcode pre_transfer(struct per_transfer *per)
      /* we ignore file size for char/block devices, sockets, etc. */
      if(S_ISREG(fileinfo.st_mode))
        uploadfilesize = fileinfo.st_size;
@@ -99,7 +104,7 @@ index c9bb636..e1e0c27 100644
  
  #ifdef DEBUGBUILD
      /* allow dedicated test cases to override */
-@@ -694,6 +756,21 @@ static CURLcode post_close_output(struct per_transfer *per,
+@@ -694,6 +761,21 @@ static CURLcode post_close_output(struct per_transfer *per,
    /* Close the outs file */
    if(outs->fopened && outs->stream) {
      rc = curlx_fclose(outs->stream);
@@ -121,7 +126,7 @@ index c9bb636..e1e0c27 100644
      if(!result && rc) {
        /* something went wrong in the writing process */
        result = CURLE_WRITE_ERROR;
-@@ -753,8 +830,18 @@ static CURLcode post_per_transfer(struct per_transfer *per,
+@@ -753,8 +835,18 @@ static CURLcode post_per_transfer(struct per_transfer *per,
    }
    else
  #endif
@@ -142,7 +147,7 @@ index c9bb636..e1e0c27 100644
  
    if(!per->skip) {
      result = post_check_result(per, result);
-@@ -1142,12 +1229,23 @@ static CURLcode setup_outfile(struct OperationConfig *config,
+@@ -1142,12 +1234,23 @@ static CURLcode setup_outfile(struct OperationConfig *config,
                               "ctx=stm", "rfm=stmlf", "rat=cr", "mrs=0");
  #else
      /* open file for output: */
@@ -166,21 +171,21 @@ index c9bb636..e1e0c27 100644
      outs->fopened = TRUE;
      outs->stream = file;
      outs->init = config->resume_from;
-@@ -1404,7 +1502,35 @@ static CURLcode create_single(struct OperationConfig *config,
+@@ -1404,7 +1507,35 @@ static CURLcode create_single(struct OperationConfig *config,
          curl_easy_cleanup(curl);
          return CURLE_FAILED_INIT;
        }
-+if(config->upload_encoding && !strcasecmp(config->upload_encoding, "ascii"))
++      if(config->upload_encoding && !strcasecmp(config->upload_encoding, "ascii"))
 +        per->convert_ascii = TRUE;
 +#ifdef __MVS__
 +      /* Initialize encoding context for z/OS UNIX file upload */
 +      if(config->upload_encoding_unix && !per->convert_ascii) {
-+        per->encoding_ctx = malloc(sizeof(encoding_ctx_t));
-+        if(per->encoding_ctx) {
-+          if(encoding_init((encoding_ctx_t*)per->encoding_ctx,
++        per->upload_encoding_ctx = malloc(sizeof(encoding_ctx_t));
++        if(per->upload_encoding_ctx) {
++          if(encoding_init((encoding_ctx_t*)per->upload_encoding_ctx,
 +                          config->upload_encoding_unix, 1) != 0) {
-+            free(per->encoding_ctx);
-+            per->encoding_ctx = NULL;
++            free(per->upload_encoding_ctx);
++            per->upload_encoding_ctx = NULL;
 +          }
 +        }
 +      }
@@ -189,12 +194,12 @@ index c9bb636..e1e0c27 100644
 +#ifdef __MVS__
 +    /* Initialize encoding context for download */
 +    if(config->download_encoding) {
-+      per->encoding_ctx = malloc(sizeof(encoding_ctx_t));
-+      if(per->encoding_ctx) {
-+        if(encoding_init((encoding_ctx_t*)per->encoding_ctx,
++      per->download_encoding_ctx = malloc(sizeof(encoding_ctx_t));
++      if(per->download_encoding_ctx) {
++        if(encoding_init((encoding_ctx_t*)per->download_encoding_ctx,
 +                        config->download_encoding, 0) != 0) {
-+          free(per->encoding_ctx);
-+          per->encoding_ctx = NULL;
++          free(per->download_encoding_ctx);
++          per->download_encoding_ctx = NULL;
 +        }
 +      }
 +   }
@@ -202,7 +207,7 @@ index c9bb636..e1e0c27 100644
      per->config = config;
      per->curl = curl;
      per->urlnum = u->num;
-@@ -2524,3 +2650,195 @@ CURLcode operate(int argc, argv_item_t argv[])
+@@ -2524,3 +2655,201 @@ CURLcode operate(int argc, argv_item_t argv[])
  
    return result;
  }
@@ -319,11 +324,11 @@ index c9bb636..e1e0c27 100644
 +    return 0;
 +
 +  case ENCODING_E2A:
-+    __e2a_s(buffer);
++    __e2a_l(buffer, *size);
 +    return 0;
 +
 +  case ENCODING_A2E:
-+    __a2e_s(buffer);
++    __a2e_l(buffer, *size);
 +    return 0;
 +
 +  case ENCODING_ICONV: {
@@ -393,6 +398,12 @@ index c9bb636..e1e0c27 100644
 +  if(ctx->iconv_cd) {
 +    iconv_close((iconv_t)ctx->iconv_cd);
 +    ctx->iconv_cd = NULL;
++  }
++
++  if(ctx->conv_buf) {
++    free(ctx->conv_buf);
++    ctx->conv_buf = NULL;
++    ctx->conv_buf_size = 0;
 +  }
 +
 +  memset(ctx, 0, sizeof(encoding_ctx_t));

--- a/stable-patches/src/tool_operate.c.patch
+++ b/stable-patches/src/tool_operate.c.patch
@@ -1,5 +1,5 @@
 diff --git a/src/tool_operate.c b/src/tool_operate.c
-index 3ad30ca..8fb5308 100644
+index c9bb636..e1e0c27 100644
 --- a/src/tool_operate.c
 +++ b/src/tool_operate.c
 @@ -25,6 +25,14 @@
@@ -50,15 +50,29 @@ index 3ad30ca..8fb5308 100644
  static CURLcode pre_transfer(struct per_transfer *per)
  {
    curl_off_t uploadfilesize = -1;
-@@ -251,6 +278,26 @@ static CURLcode pre_transfer(struct per_transfer *per)
+@@ -251,6 +278,40 @@ static CURLcode pre_transfer(struct per_transfer *per)
    CURLcode result = CURLE_OK;
  
    if(per->uploadfile && !stdin_upload(per->uploadfile)) {
 +#ifdef __MVS__
 +    /* z/OS: Check if this is a dataset (starts with //) */
 +    if(is_dataset(per->uploadfile)) {
-+      /* Use fopen for z/OS datasets with record mode */
-+      per->infp = fopen(per->uploadfile, "rb,type=record");
++      /* Determine fopen mode based on upload encoding
++       * Binary mode for binary data, text mode for text data */
++      const char *fopen_mode;
++      struct OperationConfig *config = per->config;
++      
++      if(config->upload_encoding && 
++         !strcasecmp(config->upload_encoding, "binary")) {
++        /* Binary mode: no newline conversion, preserves binary data */
++        fopen_mode = "rb,type=record";
++      }
++      else {
++        /* Text mode: converts record boundaries to \n for text datasets */
++        fopen_mode = "r";
++      }
++      
++      per->infp = fopen(per->uploadfile, fopen_mode);
 +      if(!per->infp) {
 +        helpf("cannot open dataset '%s'", per->uploadfile);
 +        return CURLE_READ_ERROR;
@@ -77,7 +91,7 @@ index 3ad30ca..8fb5308 100644
      /* VMS Note:
       *
       * Reading binary from files can be a problem... Only FIXED, VAR
-@@ -299,6 +346,7 @@ static CURLcode pre_transfer(struct per_transfer *per)
+@@ -299,6 +360,7 @@ static CURLcode pre_transfer(struct per_transfer *per)
      /* we ignore file size for char/block devices, sockets, etc. */
      if(S_ISREG(fileinfo.st_mode))
        uploadfilesize = fileinfo.st_size;
@@ -85,7 +99,7 @@ index 3ad30ca..8fb5308 100644
  
  #ifdef DEBUGBUILD
      /* allow dedicated test cases to override */
-@@ -694,6 +742,21 @@ static CURLcode post_close_output(struct per_transfer *per,
+@@ -694,6 +756,21 @@ static CURLcode post_close_output(struct per_transfer *per,
    /* Close the outs file */
    if(outs->fopened && outs->stream) {
      rc = curlx_fclose(outs->stream);
@@ -107,7 +121,7 @@ index 3ad30ca..8fb5308 100644
      if(!result && rc) {
        /* something went wrong in the writing process */
        result = CURLE_WRITE_ERROR;
-@@ -752,8 +815,18 @@ static CURLcode post_per_transfer(struct per_transfer *per,
+@@ -753,8 +830,18 @@ static CURLcode post_per_transfer(struct per_transfer *per,
    }
    else
  #endif
@@ -128,7 +142,7 @@ index 3ad30ca..8fb5308 100644
  
    if(!per->skip) {
      result = post_check_result(per, result);
-@@ -1134,12 +1207,23 @@ static CURLcode setup_outfile(struct OperationConfig *config,
+@@ -1142,12 +1229,23 @@ static CURLcode setup_outfile(struct OperationConfig *config,
                               "ctx=stm", "rfm=stmlf", "rat=cr", "mrs=0");
  #else
      /* open file for output: */
@@ -152,7 +166,7 @@ index 3ad30ca..8fb5308 100644
      outs->fopened = TRUE;
      outs->stream = file;
      outs->init = config->resume_from;
-@@ -1396,7 +1480,35 @@ static CURLcode create_single(struct OperationConfig *config,
+@@ -1404,7 +1502,35 @@ static CURLcode create_single(struct OperationConfig *config,
          curl_easy_cleanup(curl);
          return CURLE_FAILED_INIT;
        }
@@ -188,7 +202,7 @@ index 3ad30ca..8fb5308 100644
      per->config = config;
      per->curl = curl;
      per->urlnum = u->num;
-@@ -2518,3 +2630,195 @@ CURLcode operate(int argc, argv_item_t argv[])
+@@ -2524,3 +2650,195 @@ CURLcode operate(int argc, argv_item_t argv[])
  
    return result;
  }

--- a/stable-patches/src/tool_operate.h.patch
+++ b/stable-patches/src/tool_operate.h.patch
@@ -1,8 +1,8 @@
 diff --git a/src/tool_operate.h b/src/tool_operate.h
-index 69b304d..ce402c8 100644
+index 69b304d..1ea3dfa 100644
 --- a/src/tool_operate.h
 +++ b/src/tool_operate.h
-@@ -29,6 +29,36 @@
+@@ -29,6 +29,38 @@
  #include "tool_cb_prg.h"
  #include "tool_cfgable.h"
  
@@ -24,6 +24,8 @@ index 69b304d..ce402c8 100644
 +  char *to_encoding;
 +  void *iconv_cd;
 +  unsigned short ccsid;
++  char *conv_buf;      /* cached conversion buffer */
++  size_t conv_buf_size; /* size of cached conversion buffer */
 +} encoding_ctx_t;
 +
 +/* Encoding function declarations */
@@ -39,7 +41,7 @@ index 69b304d..ce402c8 100644
  struct per_transfer {
    char errorbuffer[CURL_ERROR_SIZE];
    /* double linked */
-@@ -47,6 +77,7 @@ struct per_transfer {
+@@ -47,6 +79,7 @@ struct per_transfer {
    curl_off_t urlnum; /* the index of the given URL */
    char *outfile;
    int infd;
@@ -47,7 +49,7 @@ index 69b304d..ce402c8 100644
    struct ProgressData progressbar;
    struct OutStruct outs;
    struct OutStruct heads;
-@@ -68,7 +99,12 @@ struct per_transfer {
+@@ -68,7 +101,13 @@ struct per_transfer {
    BIT(dltotal_added); /* if the total has been added from this */
    BIT(ultotal_added);
    BIT(infdopen); /* TRUE if infd needs closing */
@@ -55,7 +57,8 @@ index 69b304d..ce402c8 100644
 +  BIT(convert_ascii); /* TRUE if converting to ASCII on upload */
    BIT(noprogress);
 +#ifdef __MVS__
-+  void *encoding_ctx; /* encoding conversion context for z/OS */
++  void *upload_encoding_ctx;   /* upload encoding conversion context */
++  void *download_encoding_ctx; /* download encoding conversion context */
 +#endif
    BIT(was_last_header_empty);
  

--- a/stable-patches/src/tool_sdecls.h.patch
+++ b/stable-patches/src/tool_sdecls.h.patch
@@ -1,5 +1,5 @@
 diff --git a/src/tool_sdecls.h b/src/tool_sdecls.h
-index 9a6f3cc..3eb8ebc 100644
+index c70dbd3..38debf1 100644
 --- a/src/tool_sdecls.h
 +++ b/src/tool_sdecls.h
 @@ -75,6 +75,7 @@ struct OutStruct {

--- a/stable-patches/tests/data/test1400.patch
+++ b/stable-patches/tests/data/test1400.patch
@@ -1,5 +1,5 @@
 diff --git a/tests/data/test1400 b/tests/data/test1400
-index cf4aabb..fe839a8 100644
+index d3279a9..3874382 100644
 --- a/tests/data/test1400
 +++ b/tests/data/test1400
 @@ -32,7 +32,7 @@ http

--- a/stable-patches/tests/data/test1401.patch
+++ b/stable-patches/tests/data/test1401.patch
@@ -1,5 +1,5 @@
 diff --git a/tests/data/test1401 b/tests/data/test1401
-index 3f84805..577764e 100644
+index 74d1748..ef92eae 100644
 --- a/tests/data/test1401
 +++ b/tests/data/test1401
 @@ -40,7 +40,7 @@ cookies

--- a/stable-patches/tests/data/test1402.patch
+++ b/stable-patches/tests/data/test1402.patch
@@ -1,5 +1,5 @@
 diff --git a/tests/data/test1402 b/tests/data/test1402
-index 82061a3..570e13b 100644
+index 6dd6084..e525daf 100644
 --- a/tests/data/test1402
 +++ b/tests/data/test1402
 @@ -33,7 +33,7 @@ http

--- a/stable-patches/tests/data/test1403.patch
+++ b/stable-patches/tests/data/test1403.patch
@@ -1,5 +1,5 @@
 diff --git a/tests/data/test1403 b/tests/data/test1403
-index c3416a3..99db928 100644
+index 1438331..4e8cbd5 100644
 --- a/tests/data/test1403
 +++ b/tests/data/test1403
 @@ -33,7 +33,7 @@ http

--- a/stable-patches/tests/data/test1404.patch
+++ b/stable-patches/tests/data/test1404.patch
@@ -1,5 +1,5 @@
 diff --git a/tests/data/test1404 b/tests/data/test1404
-index 9fbd555..edadf32 100644
+index d1a1d52..2b60b77 100644
 --- a/tests/data/test1404
 +++ b/tests/data/test1404
 @@ -35,7 +35,7 @@ http

--- a/stable-patches/tests/data/test1405.patch
+++ b/stable-patches/tests/data/test1405.patch
@@ -1,5 +1,5 @@
 diff --git a/tests/data/test1405 b/tests/data/test1405
-index 853c967..7e7154f 100644
+index 611dbf7..526e86a 100644
 --- a/tests/data/test1405
 +++ b/tests/data/test1405
 @@ -37,7 +37,7 @@ ftp

--- a/stable-patches/tests/data/test1406.patch
+++ b/stable-patches/tests/data/test1406.patch
@@ -1,5 +1,5 @@
 diff --git a/tests/data/test1406 b/tests/data/test1406
-index 26ad1c7..e338a18 100644
+index d7c4adc..0a651dc 100644
 --- a/tests/data/test1406
 +++ b/tests/data/test1406
 @@ -25,7 +25,7 @@ smtp

--- a/stable-patches/tests/data/test1407.patch
+++ b/stable-patches/tests/data/test1407.patch
@@ -1,5 +1,5 @@
 diff --git a/tests/data/test1407 b/tests/data/test1407
-index 1436786..0581f7d 100644
+index 599eb1d..bd3ace2 100644
 --- a/tests/data/test1407
 +++ b/tests/data/test1407
 @@ -26,7 +26,7 @@ pop3

--- a/stable-patches/tests/data/test1420.patch
+++ b/stable-patches/tests/data/test1420.patch
@@ -1,5 +1,5 @@
 diff --git a/tests/data/test1420 b/tests/data/test1420
-index 57fdbe1..4aa4a53 100644
+index cdf51cd..2538d03 100644
 --- a/tests/data/test1420
 +++ b/tests/data/test1420
 @@ -32,7 +32,7 @@ imap

--- a/stable-patches/tests/data/test1465.patch
+++ b/stable-patches/tests/data/test1465.patch
@@ -1,5 +1,5 @@
 diff --git a/tests/data/test1465 b/tests/data/test1465
-index 2c4804d..a2f395a 100644
+index d8d6115..c0d6180 100644
 --- a/tests/data/test1465
 +++ b/tests/data/test1465
 @@ -30,7 +30,7 @@ http

--- a/stable-patches/tests/data/test1481.patch
+++ b/stable-patches/tests/data/test1481.patch
@@ -1,5 +1,5 @@
 diff --git a/tests/data/test1481 b/tests/data/test1481
-index 98c018b..aaf1334 100644
+index 8a0d310..567d847 100644
 --- a/tests/data/test1481
 +++ b/tests/data/test1481
 @@ -34,7 +34,7 @@ SSL

--- a/stable-patches/tests/runtests.pl.patch
+++ b/stable-patches/tests/runtests.pl.patch
@@ -1,8 +1,8 @@
 diff --git a/tests/runtests.pl b/tests/runtests.pl
-index c531409..e031134 100755
+index 6194961..a9ff39c 100755
 --- a/tests/runtests.pl
 +++ b/tests/runtests.pl
-@@ -567,6 +567,9 @@ sub checksystemfeatures {
+@@ -568,6 +568,9 @@ sub checksystemfeatures {
                  $pwd = sys_native_current_path();
                  $feature{"win32"} = 1;
              }


### PR DESCRIPTION
1.  Use fopen("r") when --upload-encoding ascii/ebcdic/other so newlines are added by LE.
2. Use fopen("rb,type=record") when --upload-encoding binary is specified to preserve binary data byte-for-byte.